### PR TITLE
record censored death values as missing rather than infinite

### DIFF
--- a/NEWS-ripserq.md
+++ b/NEWS-ripserq.md
@@ -1,1 +1,6 @@
 This branch (`ripserq`) and its sub-branches are testing grounds for planned changes to {ripserr}.
+
+# next version
+
+This version partially addresses #39 by encoding deaths that subceed the threshold as undefined (`NaN`) rather than infinite (`Inf`).
+A single infinite degree-0 feature is retained.

--- a/R/ripser-dist.R
+++ b/R/ripser-dist.R
@@ -67,6 +67,16 @@
 #'   max_dim = 1, thresh = 800
 #' )
 #' 
+#' # FIXME: inconsistent results using an alternative data set
+#' ripser_dist(
+#'   eurodist,
+#'   max_dim = 1, thresh = Inf
+#' )
+#' ripser_dist(
+#'   eurodist,
+#'   max_dim = 1, thresh = 600
+#' )
+#' 
 #' @export
 ripser_dist <- function(
     dataset,

--- a/R/ripser-dist.R
+++ b/R/ripser-dist.R
@@ -83,9 +83,6 @@ ripser_dist <- function(
     dim = max_dim, thresh = threshold, ratio = 1., p = 2L
   )
   
-  # convert not-a-number values to missing
-  ans <- lapply(ans, function(x) { x[is.nan(x)] <- NA_real_; x })
-  
   # return result
   ans
 }

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -668,8 +668,9 @@ public:
 #endif
 		  // ripserq: Accumulate pairs in an object to be returned to the user.
 #ifdef COLLECT_PERSISTENCE_PAIRS
-    for (index_t i = 0; i < n; ++i)
-      if (dset.find(i) == i) persistence_pairs[0].emplace_back(0.0, std::numeric_limits<value_t>::infinity());
+    for (index_t i = 0; i < n - 1; ++i)
+      if (dset.find(i) == i) persistence_pairs[0].emplace_back(0.0, std::numeric_limits<value_t>::quiet_NaN());
+		if (dset.find(n - 1) == n - 1) persistence_pairs[0].emplace_back(0.0, std::numeric_limits<value_t>::infinity());
 #endif
 	}
 
@@ -860,7 +861,7 @@ public:
 #endif
 				  // ripserq: Accumulate pairs in an object to be returned to the user.
 #ifdef COLLECT_PERSISTENCE_PAIRS
-				  persistence_pairs[dim].emplace_back(diameter, std::numeric_limits<value_t>::infinity());
+				  persistence_pairs[dim].emplace_back(diameter, std::numeric_limits<value_t>::quiet_NaN());
 #endif
 					break;
 				}

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -1403,8 +1403,14 @@ Rcpp::List ripser_cpp_dist(const Rcpp::NumericVector &dataset, int dim, double t
     const auto& pairs = result[d];
     Rcpp::NumericMatrix mat(pairs.size(), 2);
     for (size_t i = 0; i < pairs.size(); ++i) {
-      mat(i, 0) = pairs[i].first;
-      mat(i, 1) = pairs[i].second;
+      if (std::isnan(pairs[i].first))
+        mat(i, 0) = NA_REAL;
+      else
+        mat(i, 0) = pairs[i].first;
+      if (std::isnan(pairs[i].second))
+        mat(i, 1) = NA_REAL;
+      else
+        mat(i, 1) = pairs[i].second;
     }
     output[d] = mat;
   }

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -669,6 +669,7 @@ public:
 		  // ripserq: Accumulate pairs in an object to be returned to the user.
 #ifdef COLLECT_PERSISTENCE_PAIRS
     for (index_t i = 0; i < n - 1; ++i)
+      // ripserq: `quiet_NaN()` for deaths that subceed threshold.
       if (dset.find(i) == i) persistence_pairs[0].emplace_back(0.0, std::numeric_limits<value_t>::quiet_NaN());
 		if (dset.find(n - 1) == n - 1) persistence_pairs[0].emplace_back(0.0, std::numeric_limits<value_t>::infinity());
 #endif
@@ -861,6 +862,7 @@ public:
 #endif
 				  // ripserq: Accumulate pairs in an object to be returned to the user.
 #ifdef COLLECT_PERSISTENCE_PAIRS
+				  // ripserq: `quiet_NaN()` for deaths that subceed threshold.
 				  persistence_pairs[dim].emplace_back(diameter, std::numeric_limits<value_t>::quiet_NaN());
 #endif
 					break;

--- a/src/ripser.cpp
+++ b/src/ripser.cpp
@@ -1403,10 +1403,7 @@ Rcpp::List ripser_cpp_dist(const Rcpp::NumericVector &dataset, int dim, double t
     const auto& pairs = result[d];
     Rcpp::NumericMatrix mat(pairs.size(), 2);
     for (size_t i = 0; i < pairs.size(); ++i) {
-      if (std::isnan(pairs[i].first))
-        mat(i, 0) = NA_REAL;
-      else
-        mat(i, 0) = pairs[i].first;
+      mat(i, 0) = pairs[i].first;
       if (std::isnan(pairs[i].second))
         mat(i, 1) = NA_REAL;
       else


### PR DESCRIPTION
This PR revises the C++ source code to record death values beyond the threshold ("censored" deaths) as not-a-number rather than infinite and replace these with the missing double value `Rcpp::NA_REAL` (which corresponds to `NA_real_`) while populating the `Rcpp::NumericMatrix`.

The reason for taking two steps is that the `std::vector` storage of the persistent pairs cannot accommodate `Rcpp::NA_REAL`. One alternative would be to collect persistent pairs in a `Rcpp::NumericMatrix` throughout. Benchmark comparisons showed this option to incur significantly higher storage and runtime costs.